### PR TITLE
Add state parameter check in oauth2 client

### DIFF
--- a/readthedocs.txt
+++ b/readthedocs.txt
@@ -1,2 +1,2 @@
-django>=1.3.1
+django>=1.4.0
 -e git+https://github.com/pythonforfacebook/facebook-sdk#egg=FacebookSDK

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -329,7 +329,7 @@ class OAuth2(Client):
                 _("Received error while obtaining access token from %s: %s") % (
                     self.access_token_url, GET['error']))
 
-        if (not 'state' in GET) or (not constant_time_compare(self._state, GET['state'])):
+        if 'state' not in GET or not constant_time_compare(self._state, GET['state']):
             raise OAuthError(_("State parameter missing or incorrect"))
 
         return self.get_access_token(code=GET.get('code'))        

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -59,6 +59,7 @@ class OAuth(Client):
     
     def __init__(self, access_token=None, access_token_secret=None):
         self.consumer = oauth.Consumer(self.api_key, self.secret_key)
+
         if access_token and access_token_secret:
             self._access_token = oauth.Token(access_token, access_token_secret)
         
@@ -258,7 +259,6 @@ class OAuth2(Client):
             'scope': self.scope or '',
             'state': self.state
         }
-
         return '%s?%s' % (self.auth_url, urllib.urlencode(params))
     
     def parse_access_token(self, content):

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -329,7 +329,7 @@ class OAuth2(Client):
                 _("Received error while obtaining access token from %s: %s") % (
                     self.access_token_url, GET['error']))
 
-        if not constant_time_compare(self._state, GET['state']):
+        if (not 'state' in GET) or (not constant_time_compare(self._state, GET['state'])):
             raise OAuthError(_("State parameter missing or incorrect"))
 
         return self.get_access_token(code=GET.get('code'))        

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -11,7 +11,6 @@ import logging
 import oauth2 as oauth
 import urllib
 import urlparse
-from string import ascii_lowercase, digits
 
 logger = logging.getLogger(__name__)
 
@@ -331,7 +330,7 @@ class OAuth2(Client):
                     self.access_token_url, GET['error']))
 
         if not constant_time_compare(self._state, GET['state']):
-            raise OAuthError("State does not match: %s" % GET['state'])
+            raise OAuthError(_("State parameter missing or incorrect"))
 
         return self.get_access_token(code=GET.get('code'))        
 

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -1,6 +1,7 @@
 from django.utils.encoding import smart_unicode
 from django.utils.translation import ugettext_lazy as _
 from socialregistration.clients import Client
+from django.utils.crypto import constant_time_compare
 
 from django.conf import settings
 
@@ -333,7 +334,7 @@ class OAuth2(Client):
                 _("Received error while obtaining access token from %s: %s") % (
                     self.access_token_url, GET['error']))
 
-        if self.state != GET['state']:
+        if not constant_time_compare(self.state,GET['state']):
             raise OAuthError("State does not match: %s" % GET['state'])
 
         return self.get_access_token(code=GET.get('code'))        

--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -244,13 +244,11 @@ class OAuth2(Client):
         ca_certs = getattr(settings, 'HTTPLIB2_CA_CERTS', None)
         return httplib2.Http(ca_certs=ca_certs, timeout=TIMEOUT)
     
-    def get_redirect_url(self, state='', **kwargs):
+    def get_redirect_url(self, **kwargs):
         """
         Assemble the URL to where we'll be redirecting the user to to request
         permissions.
         """
-        if state != '':
-            self._state = state
         params = {
             'response_type': 'code',
             'client_id': self.client_id,

--- a/socialregistration/contrib/facebook/tests.py
+++ b/socialregistration/contrib/facebook/tests.py
@@ -41,7 +41,7 @@ class TestFacebook(OAuth2Test, TestCase):
     def callback(self, MockFacebook, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
         MockFacebook.side_effect = get_mock_func(self.get_facebook_data)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self._state})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc', 'state': self._state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')

--- a/socialregistration/contrib/facebook/tests.py
+++ b/socialregistration/contrib/facebook/tests.py
@@ -41,7 +41,7 @@ class TestFacebook(OAuth2Test, TestCase):
     def callback(self, MockFacebook, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
         MockFacebook.side_effect = get_mock_func(self.get_facebook_data)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self.state})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self._state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')

--- a/socialregistration/contrib/facebook/tests.py
+++ b/socialregistration/contrib/facebook/tests.py
@@ -41,7 +41,7 @@ class TestFacebook(OAuth2Test, TestCase):
     def callback(self, MockFacebook, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
         MockFacebook.side_effect = get_mock_func(self.get_facebook_data)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc'})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self.state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -265,8 +265,17 @@ class OAuth2Test(OAuthTest):
         response = self.client.get(self.get_setup_callback_url())
         return response
 
-    
-    
+    def test_state_is_invalid(self):
+        self.redirect()
+        response = self.client.get(self.get_callback_url(), {'code': 'abc', 'state': "aaaa"})
+        self.assertContains(response, "State parameter missing or incorrect")
+
+    def test_state_is_missing(self):
+        self.redirect()
+        response = self.client.get(self.get_callback_url(), {'code': 'abc'})
+        self.assertContains(response, "State parameter missing or incorrect")
+
+
 class TestContextProcessors(TestCase):
     def test_request_is_in_context(self):
         self.assertTrue('django.core.context_processors.request' in settings.TEMPLATE_CONTEXT_PROCESSORS)

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -250,13 +250,13 @@ class OAuth2Test(OAuthTest):
 
     def redirect(self):
         response = self.client.post(self.get_redirect_url())
-        self.state = re.findall('state=([\w\d]+)&',response['Location'])[0]
+        self._state = re.findall('state=([\w\d]+)&',response['Location'])[0]
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')
     def callback(self, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self.state})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self._state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -250,13 +250,13 @@ class OAuth2Test(OAuthTest):
 
     def redirect(self):
         response = self.client.post(self.get_redirect_url())
-        self._state = re.findall('state=([\w\d]+)&',response['Location'])[0]
+        self._state = re.findall('state=([\w\d]+)&', response['Location'])[0]
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')
     def callback(self, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self._state})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc', 'state': self._state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -8,6 +8,7 @@ from socialregistration.signals import login, connect
 import mock
 import urllib
 import urlparse
+import re
 
 class TemplateTagTest(object):
     def get_tag(self):
@@ -249,12 +250,13 @@ class OAuth2Test(OAuthTest):
 
     def redirect(self):
         response = self.client.post(self.get_redirect_url())
+        self.state = re.findall('state=([\w\d]+)&',response['Location'])[0]
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')
     def callback(self, MockRequest):
         MockRequest.side_effect = get_mock_func(self.get_callback_mock_response)
-        response = self.client.get(self.get_callback_url(), {'code': 'abc'})
+        response = self.client.get(self.get_callback_url(), {'code': 'abc','state':self.state})
         return response
     
     @mock.patch('socialregistration.clients.oauth.OAuth2.request')


### PR DESCRIPTION
Add support of the state parameter in the oauth2 client. This parameter is used for preventing cross-site request forgery.