### PR TITLE
Only check state parameter if we do not have access token.

### DIFF
--- a/socialregistration/clients/oauth.py
+++ b/socialregistration/clients/oauth.py
@@ -329,8 +329,9 @@ class OAuth2(Client):
                 _("Received error while obtaining access token from %s: %s") % (
                     self.access_token_url, GET['error']))
 
-        if 'state' not in GET or not constant_time_compare(self._state, GET['state']):
-            raise OAuthError(_("State parameter missing or incorrect"))
+        if self._access_token is None:
+            if ('state' not in GET or not constant_time_compare(self._state, GET['state'])):
+                raise OAuthError(_("State parameter missing or incorrect"))
 
         return self.get_access_token(code=GET.get('code'))        
 

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -5,6 +5,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from oauth2 import Client
 from socialregistration.signals import login, connect
+from socialregistration.contrib.facebook.models import FacebookProfile, FacebookAccessToken
 import mock
 import urllib
 import urlparse
@@ -274,6 +275,12 @@ class OAuth2Test(OAuthTest):
         self.redirect()
         response = self.client.get(self.get_callback_url(), {'code': 'abc'})
         self.assertContains(response, "State parameter missing or incorrect")
+
+    def test_passing_state_check(self):
+        self.redirect()
+        self.callback()
+        response = self.client.get(self.get_callback_url())
+        self.assertNotContains(response, "State parameter missing or incorrect",302)
 
 
 class TestContextProcessors(TestCase):

--- a/socialregistration/tests.py
+++ b/socialregistration/tests.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from oauth2 import Client
 from socialregistration.signals import login, connect
-from socialregistration.contrib.facebook.models import FacebookProfile, FacebookAccessToken
 import mock
 import urllib
 import urlparse


### PR DESCRIPTION
This change fix the bug when we call the callback second time without state parameter. If we have an access token then we do not need to check state parameter.