### PR TITLE
Convert all ForeignKey's with unique=True to OneToOneField's

### DIFF
--- a/socialregistration/contrib/facebook/migrations/0001_initial.py
+++ b/socialregistration/contrib/facebook/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('uid', models.CharField(max_length=255)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/facebook/models.py
+++ b/socialregistration/contrib/facebook/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect, login
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class FacebookProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     uid = models.CharField(max_length=255, blank=False, null=False)
 

--- a/socialregistration/contrib/foursquare/migrations/0001_initial.py
+++ b/socialregistration/contrib/foursquare/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('foursquare', models.CharField(max_length=255)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/foursquare/models.py
+++ b/socialregistration/contrib/foursquare/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class FoursquareProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     foursquare = models.CharField(max_length=255)
 

--- a/socialregistration/contrib/github/migrations/0001_initial.py
+++ b/socialregistration/contrib/github/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('github', models.CharField(max_length=255)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/github/models.py
+++ b/socialregistration/contrib/github/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class GithubProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     github = models.CharField(max_length = 255)
 

--- a/socialregistration/contrib/google/migrations/0001_initial.py
+++ b/socialregistration/contrib/google/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('google_id', models.CharField(max_length=255)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/instagram/migrations/0001_initial.py
+++ b/socialregistration/contrib/instagram/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('instagram', models.CharField(max_length=255)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/instagram/models.py
+++ b/socialregistration/contrib/instagram/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class InstagramProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     instagram = models.CharField(max_length = 255)
 

--- a/socialregistration/contrib/linkedin/migrations/0001_initial.py
+++ b/socialregistration/contrib/linkedin/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('linkedin_id', models.CharField(max_length=25)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/linkedin/models.py
+++ b/socialregistration/contrib/linkedin/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class LinkedInProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     linkedin_id = models.CharField(max_length=25)
 

--- a/socialregistration/contrib/tumblr/migrations/0001_initial.py
+++ b/socialregistration/contrib/tumblr/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('tumblr', models.CharField(max_length=100)),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/tumblr/models.py
+++ b/socialregistration/contrib/tumblr/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class TumblrProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     tumblr = models.CharField(max_length=100)
 

--- a/socialregistration/contrib/twitter/migrations/0001_initial.py
+++ b/socialregistration/contrib/twitter/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('twitter_id', models.PositiveIntegerField()),
                 ('site', models.ForeignKey(default=socialregistration.models.get_default_site, to='sites.Site')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, unique=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
             options={
             },

--- a/socialregistration/contrib/twitter/models.py
+++ b/socialregistration/contrib/twitter/models.py
@@ -8,7 +8,7 @@ from socialregistration.signals import connect
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class TwitterProfile(models.Model):
-    user = models.ForeignKey(AUTH_USER_MODEL, unique=True)
+    user = models.OneToOneField(AUTH_USER_MODEL)
     site = models.ForeignKey(Site, default=get_default_site)
     twitter_id = models.PositiveIntegerField()
 


### PR DESCRIPTION
Django > 1.8 complains about this and it is backwards compatible so might as well change it. Also updated the original migrations to prevent any kind of DB activity since the actual output of the migrations is noop anyway.