### PR TITLE
Fix Django 1.10 URL warning for usage of patterns() in urls.py

### DIFF
--- a/socialregistration/urls.py
+++ b/socialregistration/urls.py
@@ -1,57 +1,63 @@
 from django.conf import settings
-from socialregistration.compat.urls import *
+from django.conf.urls import url, include
 from socialregistration.views import Logout, Setup
 
-urlpatterns = patterns('',)
+urlpatterns = []
 
 if 'socialregistration.contrib.openid' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^openid/', include('socialregistration.contrib.openid.urls',
-            namespace='openid')))
+            namespace='openid'))
+    )
 
 if 'socialregistration.contrib.twitter' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^twitter/', include('socialregistration.contrib.twitter.urls',
-            namespace='twitter')))
+            namespace='twitter'))
+    )
 
 if 'socialregistration.contrib.linkedin' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^linkedin/', include('socialregistration.contrib.linkedin.urls',
-            namespace='linkedin')))
+            namespace='linkedin'))
+    )
 
 if 'socialregistration.contrib.facebook' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^facebook/', include('socialregistration.contrib.facebook.urls',
-            namespace='facebook')))
+            namespace='facebook'))
+    )
 
 if 'socialregistration.contrib.github' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^github/', include('socialregistration.contrib.github.urls',
-            namespace='github')))
+            namespace='github'))
+    )
 
 if 'socialregistration.contrib.foursquare' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^foursquare/', include('socialregistration.contrib.foursquare.urls',
-            namespace='foursquare')))
+            namespace='foursquare'))
+    )
 
 if 'socialregistration.contrib.tumblr' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^tumblr/', include('socialregistration.contrib.tumblr.urls',
-            namespace='tumblr')))
-    
+            namespace='tumblr'))
+    )
+
 if 'socialregistration.contrib.instagram' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^instagram/', include('socialregistration.contrib.instagram.urls',
-            namespace='instagram')))
+            namespace='instagram'))
+    )
 
 if 'socialregistration.contrib.google' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',
+    urlpatterns.append(
         url(r'^google/', include('socialregistration.contrib.google.urls',
-            namespace='google')))
+            namespace='google'))
+    )
 
-urlpatterns = urlpatterns + patterns('',
-    url(r'^setup/$', Setup.as_view(), name='setup'),
-    url(r'^logout/$', Logout.as_view(), name='logout'),
-)
-
+urlpatterns.append(url(r'^setup/$', Setup.as_view(), name='setup'))
+urlpatterns.append(url(r'^logout/$', Logout.as_view(), name='logout'))
 


### PR DESCRIPTION
Django currently shows the following warning:

```
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  namespace='openid')))
```

This fixes that

cc: @systemsoverload